### PR TITLE
Add Dockerfile with pnpm support for backend

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+node_modules
+apps/*/node_modules
+.dockerignore
+Dockerfile
+.git
+.gitignore
+*.log

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+FROM node:20-slim
+
+# Install pnpm via npm
+RUN npm install -g pnpm
+
+# Set work directory at repository root
+WORKDIR /app
+
+# Copy only package manifests for better cache
+COPY package.json pnpm-workspace.yaml ./
+COPY apps/backend/package.json apps/backend/package-lock.json ./apps/backend/
+
+# Install dependencies (workspace aware)
+RUN pnpm install --frozen-lockfile=false --filter ./apps/backend...
+
+# Copy the rest of the files
+COPY . .
+
+# Set working directory to the backend app
+WORKDIR /app/apps/backend
+
+CMD ["pnpm", "start"]


### PR DESCRIPTION
## Summary
- add Dockerfile that installs pnpm and sets working directory for the backend
- add `.dockerignore` to keep build context small

## Testing
- `pnpm install`

------
https://chatgpt.com/codex/tasks/task_e_688478f2375083329063630c79632e35