### PR TITLE
Add health route to backend

### DIFF
--- a/apps/backend/index.js
+++ b/apps/backend/index.js
@@ -360,6 +360,10 @@ async function extractFrame(input, timestamp, outPath) {
   });
 }
 
+app.get('/health', (req, res) => {
+  res.json({ status: 'ok' });
+});
+
 app.post('/analyze', upload.single('video'), async (req, res, next) => {
   if (!req.file) {
     return res.status(400).json({ error: 'No video file provided' });


### PR DESCRIPTION
## Summary
- add `/health` route to backend to easily check service status

## Testing
- `pnpm -r test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68854f37a5008332b9ddddbcd520061d