### PR TITLE
Fix /analyze route logging and Railway npm config

### DIFF
--- a/apps/backend/index.js
+++ b/apps/backend/index.js
@@ -363,6 +363,7 @@ app.get('/health', (req, res) => {
 });
 
 app.post('/analyze', upload.single('video'), async (req, res, next) => {
+  console.log('POST /analyze hit');
   if (!req.file) {
     return res.status(400).json({ error: 'No video file provided' });
   }

--- a/apps/backend/railway.json
+++ b/apps/backend/railway.json
@@ -1,4 +1,4 @@
 {
-  "buildCommand": "pnpm install",
-  "startCommand": "pnpm start"
+  "buildCommand": "npm install",
+  "startCommand": "npm start"
 }

--- a/apps/backend/server.js
+++ b/apps/backend/server.js
@@ -3,5 +3,5 @@ import app from './index.js';
 const PORT = process.env.PORT || 3000;
 
 app.listen(PORT, () => {
-  console.log(`Backend server listening on port ${PORT}`);
+  console.log(`Server started on port ${PORT}`);
 });


### PR DESCRIPTION
## Summary
- log when `/analyze` is hit
- log server startup clearly
- switch Railway build and start commands to use npm

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6886a398fed88332960aedb8e23c202d